### PR TITLE
Update pytz version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
   - 2.6
   - 2.7
   - pypy
-  - 3.2
   - 3.3
   - 3.4
+  - 3.5
 install:
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# timestring [![Build Status](https://secure.travis-ci.org/stevepeak/timestring.png)](http://travis-ci.org/stevepeak/timestring) [![Version](https://pypip.in/v/timestring/badge.png)](https://github.com/stevepeak/timestring) [![codecov.io](https://codecov.io/github/stevepeak/timestring/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/timestring)
+# timestring [![Build Status](https://secure.travis-ci.org/stevepeak/timestring.png)](http://travis-ci.org/stevepeak/timestring) [![Version](http://badge.kloud51.com/pypi/v/timestring/badge.svg)](https://github.com/stevepeak/timestring) [![codecov.io](https://codecov.io/github/stevepeak/timestring/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/timestring)
 
 Converting strings into usable time objects. The time objects, known as `Date` and `Range` have a number of methods that allow 
 you to easily change and manage your users input dynamically.

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(name='timestring',
       packages=['timestring'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["pytz==2013b"],
+      install_requires=["pytz>=2013b"],
       entry_points={'console_scripts': ['timestring=timestring:main']})


### PR DESCRIPTION
Un-pins pytz version to allow newer version. Fixes #25.

Also removed Python 3.2 from Travis-CI as coverage is no longer supported here. Added Python 3.5 to Travis-CI.
