### PR TITLE
Add support for Microsoft "filetime"

### DIFF
--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -70,17 +70,15 @@ class Date(object):
                     ts = ts + tz.utcoffset(new_date, is_dst=(dst_start < ts < dst_end))
                     new_date = datetime(ts.year, ts.month, ts.day)
 
-
                 if date.get('filetime'):
                     value = int(date.get('filetime'))
                     seconds = value / 10000000
                     epoch = seconds - 11644473600
                     dt = datetime(2000, 1, 1, 0, 0, 0)
                     new_date = dt.fromtimestamp(epoch)
-                
+
                 elif date.get('unixtime'):
                     new_date = datetime.fromtimestamp(int(date.get('unixtime')))
-
 
                 # !number of (days|...) (ago)?
                 elif date.get('num') and (date.get('delta') or date.get('delta_2')):

--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -474,9 +474,3 @@ class Date(object):
             return time.mktime(self.date.timetuple())
         else:
             return -1
-
-    def to_filetime(self):
-        if self.date != 'infinity':
-            return time.mktime(self.date.timetuple())
-        else:
-            return -1

--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -70,8 +70,17 @@ class Date(object):
                     ts = ts + tz.utcoffset(new_date, is_dst=(dst_start < ts < dst_end))
                     new_date = datetime(ts.year, ts.month, ts.day)
 
-                if date.get('unixtime'):
+
+                if date.get('filetime'):
+                    value = int(date.get('filetime'))
+                    seconds = value / 10000000
+                    epoch = seconds - 11644473600
+                    dt = datetime(2000, 1, 1, 0, 0, 0)
+                    new_date = dt.fromtimestamp(epoch)
+                
+                elif date.get('unixtime'):
                     new_date = datetime.fromtimestamp(int(date.get('unixtime')))
+
 
                 # !number of (days|...) (ago)?
                 elif date.get('num') and (date.get('delta') or date.get('delta_2')):
@@ -463,6 +472,12 @@ class Date(object):
             return 'infinity'
 
     def to_unixtime(self):
+        if self.date != 'infinity':
+            return time.mktime(self.date.timetuple())
+        else:
+            return -1
+
+    def to_filetime(self):
         if self.date != 'infinity':
             return time.mktime(self.date.timetuple())
         else:

--- a/timestring/Range.py
+++ b/timestring/Range.py
@@ -22,7 +22,7 @@ class Range(object):
         pgoffset = None
 
         if start is None:
-            raise TimestringInvalid("Range object requires a start valie")
+            raise TimestringInvalid("Range object requires a start value")
 
         if not isinstance(start, (Date, datetime)):
             start = str(start)

--- a/timestring/timestring_re.py
+++ b/timestring/timestring_re.py
@@ -3,6 +3,10 @@ TIMESTRING_RE = re.compile(re.sub('[\t\n\s]', '', re.sub('(\(\?\#[^\)]+\))', '',
     (
         ((?P<prefix>between|from|before|after|\>=?|\<=?|greater\s+th(a|e)n(\s+a)?|less\s+th(a|e)n(\s+a)?)\s+)?
         (
+            (?P<filetime>\d{18})
+
+            |
+
             (?P<unixtime>\d{10})
 
             |


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/windows/desktop/ms724290(v=vs.85).aspx

The so-called Microsoft "filetime" is common within Active Directory and is useful when dealing with LDAP responses. Some fields that are in filetime format include:

- `pwdLastSet`
- `accountExpires`
- `LastLogon`
- `LastLogonTimestamp`
- `LastPwdSet` 

There is 1 test that fails with `make test` but it failed before the changes I made. I haven't spent any time looking into that problem but it doesn't have anything to do with this patch.

Accept this if you'd like or I will maintain my own fork. Thanks for the really neat project, very creative use of regex :>
