### PR TITLE
Update pytz deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
   - 2.6
   - 2.7
   - pypy
-  - 3.2
   - 3.3
   - 3.4
+  - 3.5
 install:
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# timestring [![Build Status](https://secure.travis-ci.org/stevepeak/timestring.png)](http://travis-ci.org/stevepeak/timestring) [![Version](https://pypip.in/v/timestring/badge.png)](https://github.com/stevepeak/timestring) [![codecov.io](https://codecov.io/github/stevepeak/timestring/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/timestring)
+# timestring [![Build Status](https://secure.travis-ci.org/stevepeak/timestring.png)](http://travis-ci.org/stevepeak/timestring) [![Version](https://img.shields.io/pypi/v/timestring.svg)](https://github.com/stevepeak/timestring) [![codecov.io](https://codecov.io/github/stevepeak/timestring/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/timestring)
 
 Converting strings into usable time objects. The time objects, known as `Date` and `Range` have a number of methods that allow 
 you to easily change and manage your users input dynamically.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-version = '1.6.2'
+version = '1.6.3'
 classifiers = ["Development Status :: 5 - Production/Stable",
                "License :: OSI Approved :: Apache Software License",
                "Programming Language :: Python",
@@ -19,11 +19,11 @@ setup(name='timestring',
       classifiers=classifiers,
       keywords='date time range datetime datestring',
       author='@stevepeak',
-      author_email='steve@stevepeak.net',
-      url='http://github.com/stevepeak/timestring',
+      author_email='hello@codecov.io',
+      url='http://github.com/codecov/timestring',
       license='http://www.apache.org/licenses/LICENSE-2.0',
       packages=['timestring'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["pytz==2013b"],
+      install_requires=["pytz>=2013b"],
       entry_points={'console_scripts': ['timestring=timestring:main']})


### PR DESCRIPTION
* Updates dependencies on pytz to `use >=2013b`. This provides better cooperation between this package and others  that have long since moved on from ancient versions of pytz.
* Adds python 3.5 to travis-ci test suite and removes 3.2
* Replaces pypi.in badge (broken) with shields.io badge. 